### PR TITLE
Bugfix #13 shift click not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fix issue #13, incompatibility with customized shift-clicking from the Menu Swapper plugin
+
 ### Removed
 
 ---

--- a/src/main/java/no/elg/ii/feature/EquipFeature.java
+++ b/src/main/java/no/elg/ii/feature/EquipFeature.java
@@ -50,6 +50,7 @@ import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
 import net.runelite.http.api.item.ItemEquipmentStats;
@@ -73,6 +74,9 @@ public class EquipFeature implements Feature {
   @Inject
   @VisibleForTesting
   Client client;
+  @Inject
+  @VisibleForTesting
+  ClientThread clientThread;
 
   @Inject
   @Getter
@@ -91,8 +95,8 @@ public class EquipFeature implements Feature {
     if (widget != null) {
       String menuOption = event.getMenuOption();
       if (EQUIP_OPTIONS.contains(menuOption)) {
-        log.debug("Equipped item {}", WidgetUtils.debugInfo(widget));
-        equip(widget);
+        log.debug("'{}' item {}", menuOption, WidgetUtils.debugInfo(widget));
+        clientThread.invokeAtTickEnd(() -> equip(widget));
       }
     }
   }


### PR DESCRIPTION
I think the problem was with the menu swapper looking at the current item id in the clicked item. Since we change the item id to display the future item, the plugin miscalculated what to do somehow.

The fix is to the equipping at the end of the frame to allow menu swapper to behave correctly.